### PR TITLE
fix: S3ウェブサイトエンドポイントでURL正規化を実現

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -51,9 +51,17 @@ module "s3" {
   enable_website_configuration          = true
   index_document                        = "index.html"
   error_document                        = "404.html"
-  enable_public_access_block            = true
-  enable_bucket_policy                  = false # 一時的に無効化
-  cloudfront_origin_access_identity_arn = null  # 一時的にnull
+  enable_public_access_block            = false
+  enable_bucket_policy                  = true
+  cloudfront_origin_access_identity_arn = null
+}
+
+# =============================================================================
+# CloudFront Origin Access Identity（循環依存回避のため先に作成）
+# =============================================================================
+
+resource "aws_cloudfront_origin_access_identity" "main" {
+  comment = "OAI for ${local.name_prefix}"
 }
 
 # =============================================================================
@@ -63,16 +71,18 @@ module "s3" {
 module "cloudfront" {
   source = "./modules/cloudfront"
 
-  s3_bucket_id           = module.s3.bucket_id
-  s3_bucket_arn          = module.s3.bucket_arn
-  price_class            = var.cloudfront_price_class
-  default_ttl            = var.cloudfront_default_ttl
-  min_ttl                = var.cloudfront_min_ttl
-  max_ttl                = var.cloudfront_max_ttl
-  enable_cloudwatch_logs = var.enable_cloudwatch_logs
-  enable_compression     = true
-  enable_https           = true
-  tags                   = local.tags
+  s3_bucket_id                   = module.s3.bucket_id
+  s3_bucket_arn                  = module.s3.bucket_arn
+  origin_access_identity_iam_arn = aws_cloudfront_origin_access_identity.main.iam_arn
+  origin_access_identity_path    = aws_cloudfront_origin_access_identity.main.cloudfront_access_identity_path
+  price_class                    = var.cloudfront_price_class
+  default_ttl                    = var.cloudfront_default_ttl
+  min_ttl                        = var.cloudfront_min_ttl
+  max_ttl                        = var.cloudfront_max_ttl
+  enable_cloudwatch_logs         = var.enable_cloudwatch_logs
+  enable_compression             = true
+  enable_https                   = true
+  tags                           = local.tags
 
   depends_on = [module.s3]
 }

--- a/terraform/modules/cloudfront/main.tf
+++ b/terraform/modules/cloudfront/main.tf
@@ -2,11 +2,6 @@
 # CloudFrontモジュール メイン設定
 # =============================================================================
 
-# CloudFrontオリジンアクセスアイデンティティ
-resource "aws_cloudfront_origin_access_identity" "main" {
-  comment = "OAI for S3 bucket ${var.s3_bucket_id}"
-}
-
 # CloudFrontディストリビューション
 resource "aws_cloudfront_distribution" "main" {
   enabled             = true
@@ -14,14 +9,18 @@ resource "aws_cloudfront_distribution" "main" {
   price_class         = var.price_class
   retain_on_delete    = false
   wait_for_deployment = false
+  default_root_object = "index.html"
 
-  # オリジン設定
+  # オリジン設定（S3ウェブサイトエンドポイント使用）
   origin {
-    domain_name = "${var.s3_bucket_id}.s3.amazonaws.com"
-    origin_id   = "S3-${var.s3_bucket_id}"
+    domain_name = "${var.s3_bucket_id}.s3-website-ap-northeast-1.amazonaws.com"
+    origin_id   = "S3-Website-${var.s3_bucket_id}"
 
-    s3_origin_config {
-      origin_access_identity = aws_cloudfront_origin_access_identity.main.cloudfront_access_identity_path
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "http-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
     }
   }
 
@@ -29,7 +28,7 @@ resource "aws_cloudfront_distribution" "main" {
   default_cache_behavior {
     allowed_methods        = var.allowed_methods
     cached_methods         = var.cached_methods
-    target_origin_id       = "S3-${var.s3_bucket_id}"
+    target_origin_id       = "S3-Website-${var.s3_bucket_id}"
     viewer_protocol_policy = var.enable_https ? "redirect-to-https" : "allow-all"
     compress               = var.enable_compression
 
@@ -45,17 +44,17 @@ resource "aws_cloudfront_distribution" "main" {
     max_ttl     = var.max_ttl
   }
 
-  # エラーページ設定
+  # エラーページ設定（Hugo静的サイト用）
   custom_error_response {
     error_code         = 404
-    response_code      = "200"
-    response_page_path = "/index.html"
+    response_code      = "404"
+    response_page_path = "/404.html"
   }
 
   custom_error_response {
     error_code         = 403
-    response_code      = "200"
-    response_page_path = "/index.html"
+    response_code      = "403"
+    response_page_path = "/404.html"
   }
 
   # ログ設定（オプション）
@@ -87,7 +86,7 @@ resource "aws_cloudfront_distribution" "main" {
     Purpose = "Static Website CDN"
   })
 
-  depends_on = [aws_cloudfront_origin_access_identity.main]
+
 }
 
 # CloudFrontキャッシュポリシー（オプション）

--- a/terraform/modules/cloudfront/outputs.tf
+++ b/terraform/modules/cloudfront/outputs.tf
@@ -22,20 +22,7 @@ output "hosted_zone_id" {
   value       = aws_cloudfront_distribution.main.hosted_zone_id
 }
 
-output "origin_access_identity_id" {
-  description = "CloudFrontオリジンアクセスアイデンティティのID"
-  value       = aws_cloudfront_origin_access_identity.main.id
-}
 
-output "origin_access_identity_arn" {
-  description = "CloudFrontオリジンアクセスアイデンティティのARN"
-  value       = aws_cloudfront_origin_access_identity.main.iam_arn
-}
-
-output "origin_access_identity_path" {
-  description = "CloudFrontオリジンアクセスアイデンティティのパス"
-  value       = aws_cloudfront_origin_access_identity.main.cloudfront_access_identity_path
-}
 
 output "cache_policy_id" {
   description = "CloudFrontキャッシュポリシーのID"

--- a/terraform/modules/cloudfront/variables.tf
+++ b/terraform/modules/cloudfront/variables.tf
@@ -77,3 +77,13 @@ variable "cached_methods" {
   type        = list(string)
   default     = ["GET", "HEAD"]
 }
+
+variable "origin_access_identity_iam_arn" {
+  description = "CloudFront Origin Access IdentityのIAM ARN"
+  type        = string
+}
+
+variable "origin_access_identity_path" {
+  description = "CloudFront Origin Access Identityのパス"
+  type        = string
+}

--- a/terraform/modules/s3/main.tf
+++ b/terraform/modules/s3/main.tf
@@ -65,7 +65,7 @@ resource "aws_s3_bucket_public_access_block" "website" {
 
 # S3バケットポリシー（CloudFrontからのアクセスのみ許可）
 resource "aws_s3_bucket_policy" "website" {
-  count = var.enable_bucket_policy && var.cloudfront_origin_access_identity_arn != null ? 1 : 0
+  count = var.enable_bucket_policy ? 1 : 0
 
   bucket = aws_s3_bucket.website.id
 
@@ -73,13 +73,11 @@ resource "aws_s3_bucket_policy" "website" {
     Version = "2012-10-17"
     Statement = [
       {
-        Sid    = "AllowCloudFrontAccess"
-        Effect = "Allow"
-        Principal = {
-          AWS = var.cloudfront_origin_access_identity_arn
-        }
-        Action   = "s3:GetObject"
-        Resource = "${aws_s3_bucket.website.arn}/*"
+        Sid       = "PublicReadGetObject"
+        Effect    = "Allow"
+        Principal = "*"
+        Action    = "s3:GetObject"
+        Resource  = "${aws_s3_bucket.website.arn}/*"
       }
     ]
   })

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -63,7 +63,7 @@ output "security_info" {
   description = "セキュリティ情報"
   value = {
     s3_bucket_policy                  = module.s3.bucket_policy_id
-    cloudfront_origin_access_identity = module.cloudfront.origin_access_identity_id
+    cloudfront_origin_access_identity = aws_cloudfront_origin_access_identity.main.id
   }
   sensitive = true
 }


### PR DESCRIPTION
## 🛠️ 修正概要
ページ遷移の問題を解決するため、S3ウェブサイトエンドポイントを使用してURL正規化を実現しました。

## 📋 主な変更内容

### CloudFront設定
- **オリジン変更**:  → 
- **URL正規化**:  →  の自動変換を有効化
- **default_root_object**:  を追加
- **カスタムエラーレスポンス**: SPA用設定から静的サイト用に最適化

### S3設定
- **バケットポリシー**: OAI用からパブリック読み取り用に変更
- **パブリックアクセスブロック**: 無効化（ウェブサイトホスティング対応）
- **アクセス制御**:  でパブリック読み取り許可

### セキュリティ影響
- ❌ **OAI削除**: CloudFront Origin Access Identity使用不可
- ✅ **パブリック読み取り**: S3バケットへの読み取りアクセス許可
- ✅ **HTTPS強制**: CloudFront経由でHTTPS通信継続

## ✅ 動作確認
- [x] トップページ: https://d3bflftl7cln1y.cloudfront.net/
- [x] Aboutページ: https://d3bflftl7cln1y.cloudfront.net/about/
- [x] 投稿一覧: https://d3bflftl7cln1y.cloudfront.net/posts/
- [x] 投稿ページ: https://d3bflftl7cln1y.cloudfront.net/posts/first-post/

## 🔧 解決した問題
- 404エラーでページにアクセスできない問題
- CloudFrontのSPA設定による不適切なリダイレクト
- Hugoの静的サイト構造とCloudFront設定の不整合

全てのページが正常に表示され、ナビゲーションが機能するようになりました。